### PR TITLE
Logic to allow other valid recipe formats

### DIFF
--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -1,67 +1,61 @@
+local function add_from_item_array(items, stack_size, category)
+  for _, item in pairs(items) do
+    if item.name and ( not item.type or item.type == "item") then
+      ReStack_Items[item.name] = {stack_size = stack_size, type = category}
+    elseif item[1] then
+      ReStack_Items[item[1]] = {stack_size = stack_size, type = category}
+    end
+  end
+end
 
 -- sets stacks for items asociated with an entity or resource
 function SelectItemByEntity(ent_type, stack_size, category)
   category = category or ent_type
   for _, entity in pairs(data.raw[ent_type]) do
+    -- log(serpent.dump(entity))
     if entity.minable then
       if entity.minable.result then
         ReStack_Items[entity.minable.result] = {stack_size = stack_size, type = category}
       elseif entity.minable.results then
-        for _, result in pairs(entity.minable.results) do
-          if result.name then
-            ReStack_Items[result.name] = {stack_size = stack_size, type = category}
-          elseif result[1] then
-            ReStack_Items[result[1]] = {stack_size = stack_size, type = category}
-          end
-        end
+        add_from_item_array(entity.minable.results, stack_size, category)
       end
     end
   end
 end
 
--- set stacks for items by recipe
+-- set stacks for recipe results (used only by smelting)
 function SelectItemsByRecipeResult(recipe, stack_size, category)
-
   local item
   if recipe.result then
-    item = recipe.result
-  elseif recipe.normal and recipe.normal.result then
-    item = recipe.normal.result
-  elseif recipe.expensive and recipe.expensive.result then
-    item = recipe.normal.result
+    ReStack_Items[recipe.result] = {stack_size = stack_size, type = category}
   end
-  if item then
-    ReStack_Items[item] = {stack_size = stack_size, type = category}
-    return
+  if recipe.normal and recipe.normal.result then
+    ReStack_Items[recipe.normal.result] = {stack_size = stack_size, type = category}
+  end
+  if recipe.expensive and recipe.expensive.result then
+    ReStack_Items[recipe.expensive.result] = {stack_size = stack_size, type = category}
   end
 
-  local items
   if recipe.results then
-    items = recipe.results
-  elseif recipe.normal and recipe.normal.results then
-    items = recipe.normal.results
-  elseif recipe.expensive and recipe.expensive.results then
-    items = recipe.expensive.results
+    add_from_item_array(recipe.results, stack_size, category)
   end
-  if items then
-    for _, result in pairs(items) do
-      if result.name then
-        ReStack_Items[result.name] = {stack_size = stack_size, type = category}
-      elseif result[1] then
-        ReStack_Items[result[1]] = {stack_size = stack_size, type = category}
-      end
-    end
+  if recipe.normal and recipe.normal.results then
+    add_from_item_array(recipe.normal.results, stack_size, category)
+  end
+  if recipe.expensive and recipe.expensive.results then
+    add_from_item_array(recipe.expensive.results, stack_size, category)
   end
 end
 
+-- set stack for all recipe input items (used only by rocket parts)
 function SelectItemsByRecipeInput(recipe, stack_size, category)
   if recipe.ingredients then
-    for n, ingredient in pairs(recipe.ingredients) do
-      if ingredient.name then
-        ReStack_Items[ingredient.name] = {stack_size = stack_size, type = category}
-      elseif ingredient[1] then
-        ReStack_Items[ingredient[1]] = {stack_size = stack_size, type = category}
-      end
-    end
+    add_from_item_array(recipe.ingredients, stack_size, category)
+  end
+  if recipe.normal and recipe.normal.ingredients then
+    add_from_item_array(recipe.normal.ingredients, stack_size, category)
+  end
+  if recipe.expensive and recipe.expensive.ingredients then
+    add_from_item_array(recipe.expensive.ingredients, stack_size, category)
   end
 end

--- a/modules/lib.lua
+++ b/modules/lib.lua
@@ -8,7 +8,11 @@ function SelectItemByEntity(ent_type, stack_size, category)
         ReStack_Items[entity.minable.result] = {stack_size = stack_size, type = category}
       elseif entity.minable.results then
         for _, result in pairs(entity.minable.results) do
-          ReStack_Items[result.name] = {stack_size = stack_size, type = category}
+          if result.name then
+            ReStack_Items[result.name] = {stack_size = stack_size, type = category}
+          elseif result[1] then
+            ReStack_Items[result[1]] = {stack_size = stack_size, type = category}
+          end
         end
       end
     end
@@ -17,21 +21,45 @@ end
 
 -- set stacks for items by recipe
 function SelectItemsByRecipeResult(recipe, stack_size, category)
-  if recipe.result or (recipe.normal and recipe.normal.result) then
-    local item = recipe.result or recipe.normal.result
+
+  local item
+  if recipe.result then
+    item = recipe.result
+  elseif recipe.normal and recipe.normal.result then
+    item = recipe.normal.result
+  elseif recipe.expensive and recipe.expensive.result then
+    item = recipe.normal.result
+  end
+  if item then
     ReStack_Items[item] = {stack_size = stack_size, type = category}
-  elseif recipe.results or (recipe.normal and recipe.normal.results) then
-    local results = recipe.results or recipe.normal.results -- is normal.results even possible?
-    for _, result in pairs(results) do
-      ReStack_Items[result.name] = {stack_size = stack_size, type = category}
+    return
+  end
+
+  local items
+  if recipe.results then
+    items = recipe.results
+  elseif recipe.normal and recipe.normal.results then
+    items = recipe.normal.results
+  elseif recipe.expensive and recipe.expensive.results then
+    items = recipe.expensive.results
+  end
+  if items then
+    for _, result in pairs(items) do
+      if result.name then
+        ReStack_Items[result.name] = {stack_size = stack_size, type = category}
+      elseif result[1] then
+        ReStack_Items[result[1]] = {stack_size = stack_size, type = category}
+      end
     end
   end
 end
 
 function SelectItemsByRecipeInput(recipe, stack_size, category)
   if recipe.ingredients then
-    for n, ingredient in pairs(recipe.ingredients) do          
-      if ingredient[1] then
+    for n, ingredient in pairs(recipe.ingredients) do
+      if ingredient.name then
+        ReStack_Items[ingredient.name] = {stack_size = stack_size, type = category}
+      elseif ingredient[1] then
         ReStack_Items[ingredient[1]] = {stack_size = stack_size, type = category}
       end
     end


### PR DESCRIPTION
Both ingredients and results can take either format:
{"iron-plate", 1} or
{type="item", name="iron-plate", amount=1}

Also, a valid, but rarely used recipe format is to
specify either .normal or .expensive, but not the other.